### PR TITLE
Customizable Timeout for API Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ This version enhances the flexibility and robustness of the Completions class, e
   *	**Example**: If you're using `spectre` inside a gem, the `detect_prompts_path` method will now correctly resolve the prompts path within the gem project root.
   *	If no markers are found, the system falls back to the current working directory (`Dir.pwd`).
 
+
 # Changelog for Version 1.1.3
 
 **Release Date:** [2nd Dec 2024]
@@ -103,3 +104,38 @@ This version enhances the flexibility and robustness of the Completions class, e
 
 * **Removed unnecessary validations in `Completions` class**
   * Removed redundant validations in the `Completions` class that were causing unnecessary errors in specific edge cases. LLM providers returns a proper errors messages now.
+
+
+# Changelog for Version 1.1.4
+
+**Release Date:** [5th Dec 2024]
+
+**New Features:**
+
+* Customizable Timeout for API Requests
+* Introduced DEFAULT_TIMEOUT constant (set to 60 seconds) for managing request timeouts across the Completions and Embeddings classes.
+* Added optional arguments (args) to create methods, allowing users to override read_timeout and open_timeout dynamically.
+* This change ensures greater flexibility when dealing with varying network conditions or API response times.
+
+**Example Usage:**
+
+```ruby
+Spectre::Openai::Completions.create(
+  messages: messages,
+  read_timeout: 30,
+  open_timeout: 20
+)
+```
+
+**Key Changes:**
+
+* **Updated Completions class:**
+  * http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+  * http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
+  * Updated Embeddings class with the same timeout handling logic.
+
+**Fixes:**
+
+* Simplified Exception Handling for Timeouts
+* Removed explicit handling of Net::OpenTimeout and Net::ReadTimeout exceptions in both Completions and Embeddings classes.
+* Letting these exceptions propagate ensures clearer and more consistent error messages for timeout issues.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spectre_ai (1.1.3)
+    spectre_ai (1.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spectre/openai/completions.rb
+++ b/lib/spectre/openai/completions.rb
@@ -9,6 +9,7 @@ module Spectre
     class Completions
       API_URL = 'https://api.openai.com/v1/chat/completions'
       DEFAULT_MODEL = 'gpt-4o-mini'
+      DEFAULT_TIMEOUT = 60
 
       # Class method to generate a completion based on user messages and optional tools
       #
@@ -17,10 +18,11 @@ module Spectre
       # @param json_schema [Hash, nil] An optional JSON schema to enforce structured output
       # @param max_tokens [Integer] The maximum number of tokens for the completion (default: 50)
       # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
+      # @param args [Hash] Optional arguments like timeouts
       # @return [Hash] The parsed response including any function calls or content
       # @raise [APIKeyNotConfiguredError] If the API key is not set
       # @raise [RuntimeError] For general API errors or unexpected issues
-      def self.create(messages:, model: DEFAULT_MODEL, json_schema: nil, max_tokens: nil, tools: nil)
+      def self.create(messages:, model: DEFAULT_MODEL, json_schema: nil, max_tokens: nil, tools: nil, **args)
         api_key = Spectre.api_key
         raise APIKeyNotConfiguredError, "API key is not configured" unless api_key
 
@@ -29,8 +31,8 @@ module Spectre
         uri = URI(API_URL)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.read_timeout = 10 # seconds
-        http.open_timeout = 10 # seconds
+        http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+        http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
 
         request = Net::HTTP::Post.new(uri.path, {
           'Content-Type' => 'application/json',
@@ -49,8 +51,6 @@ module Spectre
         handle_response(parsed_response)
       rescue JSON::ParserError => e
         raise "JSON Parse Error: #{e.message}"
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        raise "Request Timeout: #{e.message}"
       end
 
       private

--- a/lib/spectre/openai/embeddings.rb
+++ b/lib/spectre/openai/embeddings.rb
@@ -9,23 +9,25 @@ module Spectre
     class Embeddings
       API_URL = 'https://api.openai.com/v1/embeddings'
       DEFAULT_MODEL = 'text-embedding-3-small'
+      DEFAULT_TIMEOUT = 60
 
       # Class method to generate embeddings for a given text
       #
       # @param text [String] the text input for which embeddings are to be generated
       # @param model [String] the model to be used for generating embeddings, defaults to DEFAULT_MODEL
+      # # @param args [Hash] Optional arguments like timeouts
       # @return [Array<Float>] the generated embedding vector
       # @raise [APIKeyNotConfiguredError] if the API key is not set
       # @raise [RuntimeError] for general API errors or unexpected issues
-      def self.create(text, model: DEFAULT_MODEL)
+      def self.create(text, model: DEFAULT_MODEL, **args)
         api_key = Spectre.api_key
         raise APIKeyNotConfiguredError, "API key is not configured" unless api_key
 
         uri = URI(API_URL)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.read_timeout = 10 # seconds
-        http.open_timeout = 10 # seconds
+        http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+        http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
 
         request = Net::HTTP::Post.new(uri.path, {
           'Content-Type' => 'application/json',
@@ -42,8 +44,6 @@ module Spectre
         JSON.parse(response.body).dig('data', 0, 'embedding')
       rescue JSON::ParserError => e
         raise "JSON Parse Error: #{e.message}"
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        raise "Request Timeout: #{e.message}"
       end
     end
   end

--- a/lib/spectre/version.rb
+++ b/lib/spectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spectre # :nodoc:all
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/spec/spectre/openai/completions_spec.rb
+++ b/spec/spectre/openai/completions_spec.rb
@@ -69,19 +69,6 @@ RSpec.describe Spectre::Openai::Completions do
       end
     end
 
-    context 'when the request times out' do
-      before do
-        stub_request(:post, Spectre::Openai::Completions::API_URL)
-          .to_timeout
-      end
-
-      it 'raises a Request Timeout error' do
-        expect {
-          described_class.create(messages: messages)
-        }.to raise_error(RuntimeError, /Request Timeout/)
-      end
-    end
-
     context 'when the response finish_reason is length' do
       let(:incomplete_response_body) { { choices: [{ message: { content: completion }, finish_reason: 'length' }] }.to_json }
 

--- a/spec/spectre/openai/embeddings_spec.rb
+++ b/spec/spectre/openai/embeddings_spec.rb
@@ -62,18 +62,5 @@ RSpec.describe Spectre::Openai::Embeddings do
         }.to raise_error(RuntimeError, /JSON Parse Error/)
       end
     end
-
-    context 'when the request times out' do
-      before do
-        stub_request(:post, Spectre::Openai::Embeddings::API_URL)
-          .to_timeout
-      end
-
-      it 'raises a Request Timeout error' do
-        expect {
-          described_class.create(text)
-        }.to raise_error(RuntimeError, /Request Timeout/)
-      end
-    end
   end
 end


### PR DESCRIPTION
**New Features:**

* Customizable Timeout for API Requests
* Introduced DEFAULT_TIMEOUT constant (set to 60 seconds) for managing request timeouts across the Completions and Embeddings classes.
* Added optional arguments (args) to create methods, allowing users to override read_timeout and open_timeout dynamically.
* This change ensures greater flexibility when dealing with varying network conditions or API response times.

**Example Usage:**

```ruby
Spectre::Openai::Completions.create(
  messages: messages,
  read_timeout: 30,
  open_timeout: 20
)
```

**Key Changes:**

* **Updated Completions class:**
  * http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
  * http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
  * Updated Embeddings class with the same timeout handling logic.

**Fixes:**

* Simplified Exception Handling for Timeouts
* Removed explicit handling of Net::OpenTimeout and Net::ReadTimeout exceptions in both Completions and Embeddings classes.
* Letting these exceptions propagate ensures clearer and more consistent error messages for timeout issues.