### PR TITLE
Add Claude and Gemini LLM providers integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,36 @@ Key Benefits:\
 - Claude embeddings are not implemented (no native embeddings model).
 - Behavior change (Claude only): when `json_schema` is used, `:content` returns a parsed object (not a JSON string). If you relied on a string, wrap with `JSON.generate` on the caller side.
 
+
+
+# Changelog for Version 1.4.0
+
+**Release Date:** [21st Sep 2025]
+
+### New Provider: Gemini (Google)
+
+- Added Spectre::Gemini client for chat completions using Google’s OpenAI-compatible endpoint.
+- Added Spectre::Gemini embeddings using Google’s OpenAI-compatible endpoint.
+- New configuration block:
+  ```ruby
+  Spectre.setup do |c|
+    c.default_llm_provider = :gemini
+    c.gemini { |v| v.api_key = ENV['GEMINI_API_KEY'] }
+  end
+  ```
+- Supports `gemini: { max_tokens: ... }` in args to control max tokens for completions.
+- `json_schema` and `tools` are passed through in OpenAI-compatible format.
+
+### Core Wiring
+
+- Added `:gemini` to VALID_LLM_PROVIDERS and provider configuration accessors.
+- Updated Rails generator initializer template to include a gemini block.
+
+### Docs & Tests
+
+- Updated README to include Gemini in compatibility matrix and configuration example.
+- Added RSpec tests for Gemini completions and embeddings (mirroring OpenAI behavior and error handling).
+
+### Behavior Notes
+
+- Gemini OpenAI-compatible chat endpoint requires that the last message in `messages` has role 'user'. Spectre raises an ArgumentError if this requirement is not met to prevent 400 INVALID_ARGUMENT errors from the API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,7 @@ Key Benefits:\
 ✅ Improves consistency across OpenAI and Ollama providers.
 
 
-# Changelog for Version 1.3.0
+# Changelog for Version 2.0.0
 
 **Release Date:** [21st Sep 2025]
 
@@ -249,7 +249,7 @@ Key Benefits:\
 
 
 
-# Changelog for Version 1.4.0
+# Changelog for Version 2.0.0
 
 **Release Date:** [21st Sep 2025]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spectre_ai (1.3.0)
+    spectre_ai (1.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spectre_ai (1.2.0)
+    spectre_ai (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spectre_ai (1.4.0)
+    spectre_ai (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 | Feature                 | Compatibility          |
 |-------------------------|------------------------|
-| Foundation Models (LLM) | OpenAI, Ollama, Claude |
-| Embeddings              | OpenAI, Ollama         |
+| Foundation Models (LLM) | OpenAI, Ollama, Claude, Gemini |
+| Embeddings              | OpenAI, Ollama, Gemini         |
 | Vector Searching        | MongoDB Atlas          |
 | Prompt Templates        | ✅                      |
 
-**💡 Note:** We now support OpenAI, Ollama, and Claude. Next, we'll add support for additional providers (e.g., Cohere) and more vector databases (Pgvector, Pinecone, etc.). If you're looking for something a bit more extensible, we highly recommend checking out [langchainrb](https://github.com/patterns-ai-core/langchainrb).
+**💡 Note:** We now support OpenAI, Ollama, Claude, and Gemini. Next, we'll add support for additional providers (e.g., Cohere) and more vector databases (Pgvector, Pinecone, etc.). If you're looking for something a bit more extensible, we highly recommend checking out [langchainrb](https://github.com/patterns-ai-core/langchainrb).
 
 ## Installation
 
@@ -49,7 +49,7 @@ This will create a file at `config/initializers/spectre.rb`, where you can set y
 
 ```ruby
 Spectre.setup do |config|
-  config.default_llm_provider = :openai # or :claude, :ollama
+  config.default_llm_provider = :openai # or :claude, :ollama, :gemini
 
   config.openai do |openai|
     openai.api_key = ENV['OPENAI_API_KEY']
@@ -62,6 +62,10 @@ Spectre.setup do |config|
 
   config.claude do |claude|
     claude.api_key = ENV['ANTHROPIC_API_KEY']
+  end
+
+  config.gemini do |gemini|
+    gemini.api_key = ENV['GEMINI_API_KEY']
   end
 end
 ```
@@ -300,6 +304,28 @@ Spectre.provider_module::Completions.create(messages: messages, json_schema: jso
 ```
 
 - Note: Claude embeddings are not implemented (no native embeddings model).
+
+#### Gemini (Google) specifics
+
+- Chat completions use Google's OpenAI-compatible endpoint. Important: the messages array must end with a user message. If the last message is assistant/system or missing, the API returns 400 INVALID_ARGUMENT (e.g., "Please ensure that single turn requests end with a user role or the role field is empty."). Spectre validates this and raises an ArgumentError earlier to help you fix the history before making an API call.
+- Example:
+
+```ruby
+# Incorrect (ends with assistant)
+messages = [
+  { role: 'system', content: 'You are a funny assistant.' },
+  { role: 'user', content: 'Tell me a joke.' },
+  { role: 'assistant', content: "Sure, here's a joke!" }
+]
+
+# Correct (ends with user)
+messages = [
+  { role: 'system', content: 'You are a funny assistant.' },
+  { role: 'user', content: 'Tell me a joke.' },
+  { role: 'assistant', content: "Sure, here's a joke!" },
+  { role: 'user', content: 'Tell me another one.' }
+]
+```
 
 ⚙️ Function Calling (Tool Use)
 

--- a/lib/generators/spectre/templates/spectre_initializer.rb
+++ b/lib/generators/spectre/templates/spectre_initializer.rb
@@ -3,7 +3,7 @@
 require 'spectre'
 
 Spectre.setup do |config|
-  # Chose your LLM (openai, ollama)
+  # Chose your LLM (openai, ollama, claude, gemini)
   config.default_llm_provider = :openai
 
   config.openai do |openai|
@@ -13,5 +13,13 @@ Spectre.setup do |config|
   config.ollama do |ollama|
     ollama.host = ENV['OLLAMA_HOST']
     ollama.api_key = ENV['OLLAMA_API_KEY']
+  end
+
+  config.claude do |claude|
+    claude.api_key = ENV['ANTHROPIC_API_KEY']
+  end
+
+  config.gemini do |gemini|
+    gemini.api_key = ENV['GEMINI_API_KEY']
   end
 end

--- a/lib/spectre.rb
+++ b/lib/spectre.rb
@@ -5,6 +5,7 @@ require "spectre/embeddable"
 require 'spectre/searchable'
 require "spectre/openai"
 require "spectre/ollama"
+require "spectre/claude"
 require "spectre/logging"
 require 'spectre/prompt'
 require 'spectre/errors'
@@ -12,7 +13,8 @@ require 'spectre/errors'
 module Spectre
   VALID_LLM_PROVIDERS = {
     openai: Spectre::Openai,
-    ollama: Spectre::Ollama
+    ollama: Spectre::Ollama,
+    claude: Spectre::Claude
     # cohere: Spectre::Cohere,
   }.freeze
 
@@ -52,6 +54,11 @@ module Spectre
       yield @providers[:ollama] if block_given?
     end
 
+    def claude
+      @providers[:claude] ||= ClaudeConfiguration.new
+      yield @providers[:claude] if block_given?
+    end
+
     def provider_configuration
       providers[default_llm_provider] || raise("No configuration found for provider: #{default_llm_provider}")
     end
@@ -63,6 +70,10 @@ module Spectre
 
   class OllamaConfiguration
     attr_accessor :host, :api_key
+  end
+
+  class ClaudeConfiguration
+    attr_accessor :api_key
   end
 
   class << self
@@ -88,6 +99,10 @@ module Spectre
 
     def ollama_configuration
       config.providers[:ollama]
+    end
+
+    def claude_configuration
+      config.providers[:claude]
     end
 
     private

--- a/lib/spectre.rb
+++ b/lib/spectre.rb
@@ -6,6 +6,7 @@ require 'spectre/searchable'
 require "spectre/openai"
 require "spectre/ollama"
 require "spectre/claude"
+require "spectre/gemini"
 require "spectre/logging"
 require 'spectre/prompt'
 require 'spectre/errors'
@@ -14,7 +15,8 @@ module Spectre
   VALID_LLM_PROVIDERS = {
     openai: Spectre::Openai,
     ollama: Spectre::Ollama,
-    claude: Spectre::Claude
+    claude: Spectre::Claude,
+    gemini: Spectre::Gemini
     # cohere: Spectre::Cohere,
   }.freeze
 
@@ -59,6 +61,11 @@ module Spectre
       yield @providers[:claude] if block_given?
     end
 
+    def gemini
+      @providers[:gemini] ||= GeminiConfiguration.new
+      yield @providers[:gemini] if block_given?
+    end
+
     def provider_configuration
       providers[default_llm_provider] || raise("No configuration found for provider: #{default_llm_provider}")
     end
@@ -73,6 +80,10 @@ module Spectre
   end
 
   class ClaudeConfiguration
+    attr_accessor :api_key
+  end
+
+  class GeminiConfiguration
     attr_accessor :api_key
   end
 
@@ -103,6 +114,10 @@ module Spectre
 
     def claude_configuration
       config.providers[:claude]
+    end
+
+    def gemini_configuration
+      config.providers[:gemini]
     end
 
     private

--- a/lib/spectre/claude.rb
+++ b/lib/spectre/claude.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Spectre
+  module Claude
+    # Require each specific client file here
+    require_relative 'claude/completions'
+  end
+end

--- a/lib/spectre/claude/completions.rb
+++ b/lib/spectre/claude/completions.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module Spectre
+  module Claude
+    class RefusalError < StandardError; end
+
+    class Completions
+      API_URL = 'https://api.anthropic.com/v1/messages'
+      DEFAULT_MODEL = 'claude-opus-4-1'
+      DEFAULT_TIMEOUT = 60
+      ANTHROPIC_VERSION = '2023-06-01'
+
+      # Class method to generate a completion based on user messages and optional tools
+      #
+      # @param messages [Array<Hash>] The conversation messages, each with a role and content
+      # @param model [String] The model to be used for generating completions, defaults to DEFAULT_MODEL
+      # @param json_schema [Hash, nil] Optional JSON Schema; when provided, it will be converted into a tool with input_schema and forced via tool_choice unless overridden
+      # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
+      # @param tool_choice [Hash, nil] Optional tool_choice to force a specific tool use (e.g., { type: 'tool', name: 'record_summary' })
+      # @param args [Hash, nil] optional arguments like read_timeout and open_timeout. For Claude, max_tokens can be passed in the claude hash.
+      # @return [Hash] The parsed response including any tool calls or content
+      # @raise [APIKeyNotConfiguredError] If the API key is not set
+      # @raise [RuntimeError] For general API errors or unexpected issues
+      def self.create(messages:, model: DEFAULT_MODEL, json_schema: nil, tools: nil, tool_choice: nil, **args)
+        api_key = Spectre.claude_configuration&.api_key
+        raise APIKeyNotConfiguredError, "API key is not configured" unless api_key
+
+        validate_messages!(messages)
+
+        uri = URI(API_URL)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+        http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
+
+        request = Net::HTTP::Post.new(uri.path, {
+          'Content-Type' => 'application/json',
+          'x-api-key' => api_key,
+          'anthropic-version' => ANTHROPIC_VERSION
+        })
+
+        max_tokens = args.dig(:claude, :max_tokens) || 1024
+        request.body = generate_body(messages, model, json_schema, max_tokens, tools, tool_choice).to_json
+        response = http.request(request)
+
+        unless response.is_a?(Net::HTTPSuccess)
+          raise "Claude API Error: #{response.code} - #{response.message}: #{response.body}"
+        end
+
+        parsed_response = JSON.parse(response.body)
+
+        handle_response(parsed_response, schema_used: !!json_schema)
+      rescue JSON::ParserError => e
+        raise "JSON Parse Error: #{e.message}"
+      end
+
+      private
+
+      # Validate the structure and content of the messages array.
+      #
+      # @param messages [Array<Hash>] The array of message hashes to validate.
+      #
+      # @raise [ArgumentError] if the messages array is not in the expected format or contains invalid data.
+      def self.validate_messages!(messages)
+        unless messages.is_a?(Array) && messages.all? { |msg| msg.is_a?(Hash) }
+          raise ArgumentError, "Messages must be an array of message hashes."
+        end
+
+        if messages.empty?
+          raise ArgumentError, "Messages cannot be empty."
+        end
+      end
+
+      # Helper method to generate the request body for Anthropic Messages API
+      #
+      # @param messages [Array<Hash>] The conversation messages, each with a role and content
+      # @param model [String] The model to be used for generating completions
+      # @param json_schema [Hash, nil] An optional JSON schema to hint structured output
+      # @param max_tokens [Integer] The maximum number of tokens for the completion
+      # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
+      # @return [Hash] The body for the API request
+      def self.generate_body(messages, model, json_schema, max_tokens, tools, tool_choice)
+        system_prompts, chat_messages = partition_system_and_chat(messages)
+
+        body = {
+          model: model,
+          max_tokens: max_tokens,
+          messages: chat_messages
+        }
+
+        # Join multiple system prompts into one. Anthropic supports a string here.
+        body[:system] = system_prompts.join("\n\n") unless system_prompts.empty?
+
+        # If a json_schema is provided, transform it into a "virtual" tool and force its use via tool_choice (unless already provided).
+        if json_schema
+          # Normalize schema input: accept anthropic-style { json_schema: { name:, schema:, strict: } },
+          # OpenAI-like { name:, schema:, strict: }, or a raw schema object.
+          if json_schema.is_a?(Hash) && (json_schema.key?(:json_schema) || json_schema.key?("json_schema"))
+            schema_payload = json_schema[:json_schema] || json_schema["json_schema"]
+            schema_name = (schema_payload[:name] || schema_payload["name"] || "structured_output").to_s
+            schema_object = schema_payload[:schema] || schema_payload["schema"] || schema_payload
+          else
+            schema_name = (json_schema.is_a?(Hash) && (json_schema[:name] || json_schema["name"])) || "structured_output"
+            schema_object = (json_schema.is_a?(Hash) && (json_schema[:schema] || json_schema["schema"])) || json_schema
+          end
+
+          schema_tool = {
+            name: schema_name,
+            description: "Return a JSON object that strictly follows the provided input_schema.",
+            input_schema: schema_object
+          }
+
+          # Merge with any user-provided tools. Prefer a single tool by default but don't drop existing tools.
+          existing_tools = tools || []
+          body[:tools] = [schema_tool] + existing_tools
+
+          # If the caller didn't specify tool_choice, force using the schema tool.
+          body[:tool_choice] = { type: 'tool', name: schema_name } unless tool_choice
+        end
+
+        body[:tools] = tools if tools && !body.key?(:tools)
+        body[:tool_choice] = tool_choice if tool_choice
+
+        body
+      end
+
+      # Normalize content for Anthropic: preserve arrays/hashes (structured blocks), stringify otherwise
+      def self.normalize_content(content)
+        case content
+        when Array
+          content
+        when Hash
+          content
+        else
+          content.to_s
+        end
+      end
+
+      # Partition system messages and convert remaining into Anthropic-compatible messages
+      def self.partition_system_and_chat(messages)
+        system_prompts = []
+        chat_messages = []
+
+        messages.each do |msg|
+          role = (msg[:role] || msg['role']).to_s
+          content = msg[:content] || msg['content']
+
+          case role
+          when 'system'
+            system_prompts << content.to_s
+          when 'user', 'assistant'
+            chat_messages << { role: role, content: normalize_content(content) }
+          else
+            # Unknown role, treat as user to avoid API errors
+            chat_messages << { role: 'user', content: normalize_content(content) }
+          end
+        end
+
+        [system_prompts, chat_messages]
+      end
+
+      # Handles the API response, raising errors for specific cases and returning structured content otherwise
+      #
+      # @param response [Hash] The parsed API response
+      # @param schema_used [Boolean] Whether the request used a JSON schema (tools-based) and needs normalization
+      # @return [Hash] The relevant data based on the stop_reason
+      def self.handle_response(response, schema_used: false)
+        content_blocks = response['content'] || []
+        stop_reason = response['stop_reason']
+
+        text_content = content_blocks.select { |b| b['type'] == 'text' }.map { |b| b['text'] }.join
+        tool_uses = content_blocks.select { |b| b['type'] == 'tool_use' }
+
+        if stop_reason == 'max_tokens'
+          raise "Incomplete response: The completion was cut off due to token limit."
+        end
+
+        if stop_reason == 'refusal'
+          raise RefusalError, "Content filtered: The model's output was blocked due to policy violations."
+        end
+
+        # If a json_schema was provided and Claude produced a single tool_use with no text,
+        # treat it as structured JSON output and return the parsed object in :content.
+        if schema_used && tool_uses.length == 1 && (text_content.nil? || text_content.strip.empty?)
+          input = tool_uses.first['input']
+          return({ content: input }) if input.is_a?(Hash) || input.is_a?(Array)
+        end
+
+        if !tool_uses.empty?
+          return { tool_calls: tool_uses, content: text_content }
+        end
+
+        # Normal end of turn
+        if stop_reason == 'end_turn' || stop_reason.nil?
+          return { content: text_content }
+        end
+
+        # Handle unexpected stop reasons
+        raise "Unexpected stop_reason: #{stop_reason}"
+      end
+    end
+  end
+end

--- a/lib/spectre/gemini.rb
+++ b/lib/spectre/gemini.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Spectre
+  module Gemini
+    require_relative 'gemini/completions'
+    require_relative 'gemini/embeddings'
+  end
+end

--- a/lib/spectre/gemini/completions.rb
+++ b/lib/spectre/gemini/completions.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module Spectre
+  module Gemini
+    class Completions
+      # Using Google's OpenAI-compatible endpoint
+      API_URL = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
+      DEFAULT_MODEL = 'gemini-2.5-flash'
+      DEFAULT_TIMEOUT = 60
+
+      # Class method to generate a completion based on user messages and optional tools
+      #
+      # @param messages [Array<Hash>] The conversation messages, each with a role and content
+      # @param model [String] The model to be used for generating completions, defaults to DEFAULT_MODEL
+      # @param json_schema [Hash, nil] An optional JSON schema to enforce structured output (OpenAI-compatible "response_format")
+      # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
+      # @param args [Hash, nil] optional arguments like read_timeout and open_timeout. For Gemini, max_tokens can be passed in the gemini hash.
+      # @return [Hash] The parsed response including any function calls or content
+      # @raise [APIKeyNotConfiguredError] If the API key is not set
+      # @raise [RuntimeError] For general API errors or unexpected issues
+      def self.create(messages:, model: DEFAULT_MODEL, json_schema: nil, tools: nil, **args)
+        api_key = Spectre.gemini_configuration&.api_key
+        raise APIKeyNotConfiguredError, "API key is not configured" unless api_key
+
+        validate_messages!(messages)
+
+        uri = URI(API_URL)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+        http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
+
+        request = Net::HTTP::Post.new(uri.path, {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{api_key}"
+        })
+
+        max_tokens = args.dig(:gemini, :max_tokens)
+        request.body = generate_body(messages, model, json_schema, max_tokens, tools).to_json
+        response = http.request(request)
+
+        unless response.is_a?(Net::HTTPSuccess)
+          raise "Gemini API Error: #{response.code} - #{response.message}: #{response.body}"
+        end
+
+        parsed_response = JSON.parse(response.body)
+
+        handle_response(parsed_response)
+      rescue JSON::ParserError => e
+        raise "JSON Parse Error: #{e.message}"
+      end
+
+      private
+
+      # Validate the structure and content of the messages array.
+      def self.validate_messages!(messages)
+        unless messages.is_a?(Array) && messages.all? { |msg| msg.is_a?(Hash) }
+          raise ArgumentError, "Messages must be an array of message hashes."
+        end
+
+        if messages.empty?
+          raise ArgumentError, "Messages cannot be empty."
+        end
+
+        # Gemini's OpenAI-compatible chat endpoint requires that single-turn
+        # and general requests end with a user message. If not, return a clear error.
+        last_role = (messages.last[:role] || messages.last['role']).to_s
+        unless last_role == 'user'
+          raise ArgumentError, "Gemini: the last message must have role 'user'. Got '#{last_role}'."
+        end
+      end
+
+      # Helper method to generate the request body (OpenAI-compatible)
+      def self.generate_body(messages, model, json_schema, max_tokens, tools)
+        body = {
+          model: model,
+          messages: messages
+        }
+
+        body[:max_tokens] = max_tokens if max_tokens
+        body[:response_format] = { type: 'json_schema', json_schema: json_schema } if json_schema
+        body[:tools] = tools if tools
+
+        body
+      end
+
+      # Handles the API response, mirroring OpenAI semantics
+      def self.handle_response(response)
+        message = response.dig('choices', 0, 'message')
+        finish_reason = response.dig('choices', 0, 'finish_reason')
+
+        if message && message['refusal']
+          raise "Refusal: #{message['refusal']}"
+        end
+
+        if finish_reason == 'length'
+          raise "Incomplete response: The completion was cut off due to token limit."
+        end
+
+        if finish_reason == 'content_filter'
+          raise "Content filtered: The model's output was blocked due to policy violations."
+        end
+
+        if finish_reason == 'function_call' || finish_reason == 'tool_calls'
+          return { tool_calls: message['tool_calls'], content: message['content'] }
+        end
+
+        if finish_reason == 'stop'
+          return { content: message['content'] }
+        end
+
+        raise "Unexpected finish_reason: #{finish_reason}"
+      end
+    end
+  end
+end

--- a/lib/spectre/gemini/embeddings.rb
+++ b/lib/spectre/gemini/embeddings.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module Spectre
+  module Gemini
+    class Embeddings
+      # Using Google's OpenAI-compatible endpoint
+      API_URL = 'https://generativelanguage.googleapis.com/v1beta/openai/embeddings'
+      DEFAULT_MODEL = 'gemini-embedding-001'
+      DEFAULT_TIMEOUT = 60
+
+      # Generate embeddings for text
+      def self.create(text, model: DEFAULT_MODEL, **args)
+        api_key = Spectre.gemini_configuration&.api_key
+        raise APIKeyNotConfiguredError, "API key is not configured" unless api_key
+
+        uri = URI(API_URL)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.read_timeout = args.fetch(:read_timeout, DEFAULT_TIMEOUT)
+        http.open_timeout = args.fetch(:open_timeout, DEFAULT_TIMEOUT)
+
+        request = Net::HTTP::Post.new(uri.path, {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{api_key}"
+        })
+
+        request.body = { model: model, input: text }.to_json
+        response = http.request(request)
+
+        unless response.is_a?(Net::HTTPSuccess)
+          raise "Gemini API Error: #{response.code} - #{response.message}: #{response.body}"
+        end
+
+        JSON.parse(response.body).dig('data', 0, 'embedding')
+      rescue JSON::ParserError => e
+        raise "JSON Parse Error: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/spectre/version.rb
+++ b/lib/spectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spectre # :nodoc:all
-  VERSION = "1.4.0"
+  VERSION = "2.0.0"
 end

--- a/lib/spectre/version.rb
+++ b/lib/spectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spectre # :nodoc:all
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/lib/spectre/version.rb
+++ b/lib/spectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spectre # :nodoc:all
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/spectre/claude/completions_spec.rb
+++ b/spec/spectre/claude/completions_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spectre::Claude::Completions do
+  let(:api_key) { 'test_api_key' }
+  let(:messages) do
+    [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'Tell me a joke.' }
+    ]
+  end
+
+  let(:completion_text) { 'Why did the scarecrow win an award? Because he was outstanding in his field!' }
+  let(:success_response_body) do
+    {
+      content: [
+        { type: 'text', text: completion_text }
+      ],
+      stop_reason: 'end_turn'
+    }.to_json
+  end
+
+  before do
+    Spectre.setup do |config|
+      config.default_llm_provider = :claude
+      config.claude do |claude|
+        claude.api_key = api_key
+      end
+    end
+  end
+
+  describe '.create' do
+    context 'when the API key is not configured' do
+      before do
+        Spectre.setup do |config|
+          config.default_llm_provider = :claude
+          config.claude do |claude|
+            claude.api_key = nil
+          end
+        end
+      end
+
+      it 'raises an APIKeyNotConfiguredError' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(Spectre::APIKeyNotConfiguredError, 'API key is not configured')
+      end
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 200, body: success_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the completion text' do
+        result = described_class.create(messages: messages)
+        expect(result).to eq({ content: completion_text })
+      end
+    end
+
+    context 'when the API returns an error' do
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 500, body: 'Internal Server Error')
+      end
+
+      it 'raises an error with the API response' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Claude API Error/)
+      end
+    end
+
+    context 'when the response is not valid JSON' do
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 200, body: 'Invalid JSON')
+      end
+
+      it 'raises a JSON Parse Error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /JSON Parse Error/)
+      end
+    end
+
+    context 'when the response stop_reason is max_tokens' do
+      let(:incomplete_response_body) do
+        {
+          content: [ { type: 'text', text: completion_text } ],
+          stop_reason: 'max_tokens'
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 200, body: incomplete_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises an incomplete response error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Incomplete response: The completion was cut off due to token limit./)
+      end
+    end
+
+    context 'when the response stop_reason is refusal' do
+      let(:refusal_response_body) do
+        {
+          content: [ { type: 'text', text: '' } ],
+          stop_reason: 'refusal'
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 200, body: refusal_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises a refusal error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(Spectre::Claude::RefusalError, /Content filtered: The model's output was blocked due to policy violations./)
+      end
+    end
+
+    context 'when the response contains a tool_use and no json_schema was provided' do
+      let(:tool_use_response_body) do
+        {
+          content: [
+            { type: 'tool_use', id: 'tool_1', name: 'get_info', input: { query: 'something' } },
+            { type: 'text', text: 'Calling tool' }
+          ],
+          stop_reason: 'tool_use'
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, Spectre::Claude::Completions::API_URL)
+          .to_return(status: 200, body: tool_use_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns tool_calls and text content' do
+        result = described_class.create(messages: messages)
+        parsed = JSON.parse(tool_use_response_body)
+        expect(result).to eq({
+          tool_calls: parsed['content'].select { |b| b['type'] == 'tool_use' },
+          content: 'Calling tool'
+        })
+      end
+    end
+
+    context 'with a json_schema parameter' do
+      let(:json_schema) do
+        { name: 'completion_response', schema: { type: 'object', properties: { response: { type: 'string' } }, required: ['response'] } }
+      end
+
+      context 'request formation' do
+        before do
+          stub_request(:post, Spectre::Claude::Completions::API_URL)
+            .to_return(status: 200, body: success_response_body, headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'converts json_schema to a tool with input_schema and forces tool_choice by default' do
+          described_class.create(messages: messages, json_schema: json_schema)
+
+          expect(a_request(:post, Spectre::Claude::Completions::API_URL)
+            .with { |req|
+              body = JSON.parse(req.body)
+              schema_tool = body['tools']&.first
+              body['tool_choice'] == { 'type' => 'tool', 'name' => json_schema[:name] } &&
+                schema_tool && schema_tool['name'] == json_schema[:name] &&
+                schema_tool['input_schema'] == JSON.parse(json_schema[:schema].to_json)
+            }).to have_been_made.once
+        end
+
+        it 'does not override an explicit tool_choice' do
+          described_class.create(messages: messages, json_schema: json_schema, tool_choice: { type: 'auto' })
+
+          expect(a_request(:post, Spectre::Claude::Completions::API_URL)
+            .with { |req| JSON.parse(req.body)['tool_choice'] == { 'type' => 'auto' } }).to have_been_made.once
+        end
+
+        it 'includes user-provided tools along with the schema tool' do
+          tools = [{ name: 'other_tool', description: 'Other', input_schema: { type: 'object', properties: {}, additionalProperties: false } }]
+          described_class.create(messages: messages, json_schema: json_schema, tools: tools)
+
+          expect(a_request(:post, Spectre::Claude::Completions::API_URL)
+            .with { |req|
+              body = JSON.parse(req.body)
+              body['tools'].is_a?(Array) && body['tools'].any? { |t| t['name'] == 'other_tool' } && body['tools'].any? { |t| t['name'] == json_schema[:name] }
+            }).to have_been_made.once
+        end
+
+        it 'sends the claude max_tokens parameter when provided' do
+          described_class.create(messages: messages, json_schema: json_schema, claude: { max_tokens: 77 })
+          expect(a_request(:post, Spectre::Claude::Completions::API_URL)
+            .with(body: hash_including(max_tokens: 77))).to have_been_made
+        end
+      end
+
+      context 'response normalization' do
+        let(:schema_tool_name) { json_schema[:name] }
+        let(:tool_only_response_body) do
+          {
+            content: [
+              { type: 'tool_use', id: 'tool_u', name: schema_tool_name, input: { response: 'OK' } }
+            ],
+            stop_reason: 'tool_use'
+          }.to_json
+        end
+
+        before do
+          stub_request(:post, Spectre::Claude::Completions::API_URL)
+            .to_return(status: 200, body: tool_only_response_body, headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'returns the parsed tool input in :content (not a JSON string)' do
+          result = described_class.create(messages: messages, json_schema: json_schema)
+          expect(result).to eq({ content: { 'response' => 'OK' } })
+        end
+      end
+    end
+  end
+end

--- a/spec/spectre/gemini/completions_spec.rb
+++ b/spec/spectre/gemini/completions_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spectre::Gemini::Completions do
+  let(:api_key) { 'test_api_key' }
+  let(:messages) do
+    [
+      { role: 'system', content: 'You are a funny assistant.' },
+      { role: 'user', content: 'Tell me a joke.' }
+    ]
+  end
+  let(:completion) { 'Why did the chicken cross the road? To get to the other side!' }
+  let(:response_body) { { choices: [{ message: { content: completion }, finish_reason: 'stop' }] }.to_json }
+
+  before do
+    Spectre.setup do |config|
+      config.default_llm_provider = :gemini
+      config.gemini do |gemini|
+        gemini.api_key = api_key
+      end
+    end
+  end
+
+  describe '.create' do
+    context 'when the API key is not configured' do
+      before do
+        Spectre.setup do |config|
+          config.default_llm_provider = :gemini
+          config.gemini do |gemini|
+            gemini.api_key = nil
+          end
+        end
+      end
+
+      it 'raises an APIKeyNotConfiguredError' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(Spectre::APIKeyNotConfiguredError, 'API key is not configured')
+      end
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the completion text' do
+        result = described_class.create(messages: messages)
+        expect(result).to eq({ content: completion })
+      end
+    end
+
+    context 'when the API returns an error' do
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 500, body: 'Internal Server Error')
+      end
+
+      it 'raises an error with the API response' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Gemini API Error/)
+      end
+    end
+
+    context 'when the response is not valid JSON' do
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: 'Invalid JSON')
+      end
+
+      it 'raises a JSON Parse Error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /JSON Parse Error/)
+      end
+    end
+
+    context 'when the response finish_reason is length' do
+      let(:incomplete_response_body) { { choices: [{ message: { content: completion }, finish_reason: 'length' }] }.to_json }
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: incomplete_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises an incomplete response error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Incomplete response: The completion was cut off due to token limit./)
+      end
+    end
+
+    context 'when the response finish_reason is content_filter' do
+      let(:filtered_response_body) { { choices: [{ message: { content: completion }, finish_reason: 'content_filter' }] }.to_json }
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: filtered_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises a content filtered error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Content filtered: The model's output was blocked due to policy violations./)
+      end
+    end
+
+    context 'when the response contains a function call' do
+      let(:function_response_body) do
+        { choices: [{ message: { tool_calls: { function: 'get_delivery_date', parameters: { order_id: 'order_12345' } }, content: 'Function called' }, finish_reason: 'function_call' }] }.to_json
+      end
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: function_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the function call details' do
+        result = described_class.create(messages: messages)
+        expect(result).to eq({ tool_calls: { 'function' => 'get_delivery_date', 'parameters' => { 'order_id' => 'order_12345' } }, content: 'Function called' })
+      end
+    end
+
+    context 'with a max_tokens parameter' do
+      let(:max_tokens) { 30 }
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'sends the max_tokens parameter in the request' do
+        described_class.create(messages: messages, gemini: { max_tokens: max_tokens })
+
+        expect(a_request(:post, Spectre::Gemini::Completions::API_URL)
+                 .with(body: hash_including(max_tokens: max_tokens))).to have_been_made
+      end
+    end
+
+    context 'with a json_schema parameter' do
+      let(:json_schema) { { name: 'completion_response', schema: { type: 'object', properties: { response: { type: 'string' } } } } }
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'sends the json_schema in the request' do
+        described_class.create(messages: messages, json_schema: json_schema)
+
+        expect(a_request(:post, Spectre::Gemini::Completions::API_URL)
+                 .with { |req| JSON.parse(req.body)['response_format']['json_schema'] == JSON.parse(json_schema.to_json) }).to have_been_made.once
+      end
+    end
+
+    context 'when the response contains a refusal' do
+      let(:refusal_response_body) do
+        { choices: [{ message: { refusal: "I'm sorry, I cannot assist with that request." }, finish_reason: 'stop' }] }.to_json
+      end
+
+      before do
+        stub_request(:post, Spectre::Gemini::Completions::API_URL)
+          .to_return(status: 200, body: refusal_response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises a refusal error' do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(RuntimeError, /Refusal: I'm sorry, I cannot assist with that request./)
+      end
+    end
+
+    context 'when the last message is not user' do
+      let(:messages) do
+        [
+          { role: 'system', content: 'You are a funny assistant.' },
+          { role: 'user', content: 'Tell me a joke.' },
+          { role: 'assistant', content: 'Sure, here\'s a joke!' }
+        ]
+      end
+
+      it "raises an ArgumentError explaining the requirement" do
+        expect {
+          described_class.create(messages: messages)
+        }.to raise_error(ArgumentError, /Gemini: the last message must have role 'user'/)
+      end
+    end
+  end
+end

--- a/spec/spectre/gemini/embeddings_spec.rb
+++ b/spec/spectre/gemini/embeddings_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spectre::Gemini::Embeddings do
+  let(:api_key) { 'test_api_key' }
+  let(:text) { 'example text' }
+  let(:embedding) { [0.1, 0.2, 0.3] }
+  let(:response_body) { { data: [{ embedding: embedding }] }.to_json }
+
+  before do
+    Spectre.setup do |config|
+      config.default_llm_provider = :gemini
+      config.gemini do |gemini|
+        gemini.api_key = api_key
+      end
+    end
+  end
+
+  describe '.create' do
+    context 'when the API key is not configured' do
+      before do
+        Spectre.setup do |config|
+          config.default_llm_provider = :gemini
+          config.gemini do |gemini|
+            gemini.api_key = nil
+          end
+        end
+      end
+
+      it 'raises an APIKeyNotConfiguredError' do
+        expect {
+          described_class.create(text)
+        }.to raise_error(Spectre::APIKeyNotConfiguredError, 'API key is not configured')
+      end
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:post, Spectre::Gemini::Embeddings::API_URL)
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the embedding' do
+        result = described_class.create(text)
+        expect(result).to eq(embedding)
+      end
+    end
+
+    context 'when the API returns an error' do
+      before do
+        stub_request(:post, Spectre::Gemini::Embeddings::API_URL)
+          .to_return(status: 500, body: 'Internal Server Error')
+      end
+
+      it 'raises an error with the API response' do
+        expect {
+          described_class.create(text)
+        }.to raise_error(RuntimeError, /Gemini API Error/)
+      end
+    end
+
+    context 'when the response is not valid JSON' do
+      before do
+        stub_request(:post, Spectre::Gemini::Embeddings::API_URL)
+          .to_return(status: 200, body: 'Invalid JSON')
+      end
+
+      it 'raises a JSON Parse Error' do
+        expect {
+          described_class.create(text)
+        }.to raise_error(RuntimeError, /JSON Parse Error/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Changelog for Version 1.3.0

**Release Date:** [21st Sep 2025]

### New Provider: Claude (Anthropic)

- Added Spectre::Claude client for chat completions using Anthropic Messages API.
- New configuration block: `Spectre.setup { |c| c.default_llm_provider = :claude; c.claude { |v| v.api_key = ENV['ANTHROPIC_API_KEY'] } }`.
- Supports `claude: { max_tokens: ... }` in args to control max tokens.

### Structured Outputs via Tools-based JSON Schema

- Claude does not use `response_format`; instead, when `json_schema` is provided we now:
  - Convert your schema into a single “virtual” tool (`tools[0]`) with `input_schema`.
  - Force use of that tool by default with `tool_choice: { type: 'tool', name: <schema_name> }` (respects explicit `tool_choice` if you pass one).
  - Merge your own `tools` alongside the schema tool without overriding them.
- Messages content preserves structured blocks (hashes/arrays), enabling images and other block types to be sent as-is.

### Output Normalization (Parity with OpenAI when using json_schema)

- When a `json_schema` is provided and Claude returns a single `tool_use` with no text, we normalize the output to:
  - `content: <parsed_object>` (Hash/Array), not a JSON string.
  - This mirrors the behavior you get with OpenAI’s JSON schema mode, simplifying consumers.
- When no `json_schema` is provided, we return `tool_calls` (raw `tool_use` blocks) plus any text content.

### Error Handling & Stop Reasons

- `stop_reason: 'max_tokens'` → raises `"Incomplete response: The completion was cut off due to token limit."`
- `stop_reason: 'refusal'` → raises `Spectre::Claude::RefusalError`.
- Unexpected stop reasons raise an error to make issues explicit.

### Tools and tool_choice Support

- Pass-through for user-defined tools.
- Respect explicit `tool_choice`; only enforce schema tool when `json_schema` is present and no explicit choice is set.

### Tests & DX

- Added a comprehensive RSpec suite for `Spectre::Claude::Completions`.
- Ensured spec loading works consistently across environments via `.rspec --require spec_helper` and consistent requires.
- Full suite passes locally (69 examples).

### Notes

- Claude embeddings are not implemented (no native embeddings model).
- Behavior change (Claude only): when `json_schema` is used, `:content` returns a parsed object (not a JSON string). If you relied on a string, wrap with `JSON.generate` on the caller side.


# Changelog for Version 1.4.0

**Release Date:** [21st Sep 2025]

### New Provider: Gemini (Google)

- Added Spectre::Gemini client for chat completions using Google’s OpenAI-compatible endpoint.
- Added Spectre::Gemini embeddings using Google’s OpenAI-compatible endpoint.
- New configuration block:
  ```ruby
  Spectre.setup do |c|
    c.default_llm_provider = :gemini
    c.gemini { |v| v.api_key = ENV['GEMINI_API_KEY'] }
  end
  ```
- Supports `gemini: { max_tokens: ... }` in args to control max tokens for completions.
- `json_schema` and `tools` are passed through in OpenAI-compatible format.

### Core Wiring

- Added `:gemini` to VALID_LLM_PROVIDERS and provider configuration accessors.
- Updated Rails generator initializer template to include a gemini block.

### Docs & Tests

- Updated README to include Gemini in compatibility matrix and configuration example.
- Added RSpec tests for Gemini completions and embeddings (mirroring OpenAI behavior and error handling).

### Behavior Notes

- Gemini OpenAI-compatible chat endpoint requires that the last message in `messages` has role 'user'. Spectre raises an ArgumentError if this requirement is not met to prevent 400 INVALID_ARGUMENT errors from the API.

