### PR TITLE
Add support for forwarding extra generation options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spectre_ai (2.1.0)
+    spectre_ai (2.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spectre/claude/completions.rb
+++ b/lib/spectre/claude/completions.rb
@@ -22,6 +22,7 @@ module Spectre
       # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
       # @param tool_choice [Hash, nil] Optional tool_choice to force a specific tool use (e.g., { type: 'tool', name: 'record_summary' })
       # @param args [Hash, nil] optional arguments like read_timeout and open_timeout. Provide max_tokens at the top level only.
+      #   Any additional kwargs (e.g., temperature:, top_p:) will be forwarded into the request body.
       # @return [Hash] The parsed response including any tool calls or content
       # @raise [APIKeyNotConfiguredError] If the API key is not set
       # @raise [RuntimeError] For general API errors or unexpected issues
@@ -44,7 +45,9 @@ module Spectre
         })
 
         max_tokens = args[:max_tokens] || 1024
-        request.body = generate_body(messages, model, json_schema, max_tokens, tools, tool_choice).to_json
+        # Forward extra args (like temperature) into the body, excluding control/network keys
+        forwarded = args.reject { |k, _| [:read_timeout, :open_timeout, :max_tokens, :tool_choice].include?(k) }
+        request.body = generate_body(messages, model, json_schema, max_tokens, tools, tool_choice, forwarded).to_json
         response = http.request(request)
 
         unless response.is_a?(Net::HTTPSuccess)
@@ -83,7 +86,7 @@ module Spectre
       # @param max_tokens [Integer] The maximum number of tokens for the completion
       # @param tools [Array<Hash>, nil] An optional array of tool definitions for function calling
       # @return [Hash] The body for the API request
-      def self.generate_body(messages, model, json_schema, max_tokens, tools, tool_choice)
+      def self.generate_body(messages, model, json_schema, max_tokens, tools, tool_choice, forwarded)
         system_prompts, chat_messages = partition_system_and_chat(messages)
 
         body = {
@@ -124,6 +127,11 @@ module Spectre
 
         body[:tools] = tools if tools && !body.key?(:tools)
         body[:tool_choice] = tool_choice if tool_choice
+
+        # Merge any extra forwarded options (e.g., temperature, top_p)
+        if forwarded && !forwarded.empty?
+          body.merge!(forwarded.transform_keys(&:to_sym))
+        end
 
         body
       end

--- a/lib/spectre/version.rb
+++ b/lib/spectre/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spectre # :nodoc:all
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
### Enhancements: Extra generation options for Completions

- You can now pass additional generation options (e.g., `temperature`, `top_p`, `presence_penalty`) directly as keyword arguments to all `Completions.create` methods.
- For OpenAI, OpenRouter, Gemini, and Claude these extra kwargs are forwarded into the request body automatically.
- For Ollama, pass extra kwargs at the top level just like other providers. Spectre maps them into `body[:options]` internally (including `max_tokens`). The legacy `ollama: { options: ... }` is now ignored.

### Notes and exclusions

- Control/network keys are not forwarded: `read_timeout`, `open_timeout`.
- `max_tokens` remains supported:
  - OpenAI/OpenRouter/Gemini/Claude: stays a top‑level request body field.
  - Ollama: forwarded into `:options` along with other generation kwargs.
- Claude: `tool_choice` is NOT auto‑forwarded from extra kwargs; pass it explicitly via the dedicated parameter if needed.

### Examples

```ruby
# OpenAI
Spectre::Openai::Completions.create(
  messages: [ { role: 'user', content: 'Hi' } ],
  model: 'gpt-4o-mini',
  temperature: 0.1,
  top_p: 0.9,
  max_tokens: 512
)
# OpenRouter
Spectre::Openrouter::Completions.create(
  messages: [ { role: 'user', content: 'Hi' } ],
  model: 'openai/gpt-4o-mini',
  temperature: 0.1,
  presence_penalty: 0.2,
  max_tokens: 256
)
# Gemini (OpenAI‑compatible endpoint)
Spectre::Gemini::Completions.create(
  messages: [ { role: 'user', content: 'Hi' } ],
  model: 'gemini-2.5-flash',
  temperature: 0.1,
  max_tokens: 256
)
# Claude
Spectre::Claude::Completions.create(
  messages: [ { role: 'user', content: 'Hi' } ],
  model: 'claude-opus-4-1',
  temperature: 0.1,
  max_tokens: 512,
  tool_choice: { type: 'auto' } # pass explicitly when needed
)
# Ollama — pass options at top level; Spectre maps them to body[:options]
Spectre::Ollama::Completions.create(
  messages: [ { role: 'user', content: 'Hi' } ],
  model: 'llama3.1:8b',
  temperature: 0.1,
  max_tokens: 256,   # forwarded into body[:options]
  path: 'api/chat'   # optional: override endpoint path
)
## Note: `ollama: { options: ... }` is ignored; use top-level kwargs instead.
```
  - Request body formation (max_tokens, tools, response_format.json_schema).

### OpenRouter: Plugins support in chat completions

- Added pass-through support for OpenRouter Plugins in chat completions.
- You can pass the `plugins` array directly to `Spectre::Openrouter::Completions.create`, and it will be included in the request body.

Example:

```ruby
Spectre::Openrouter::Completions.create(
  messages: [ { role: 'user', content: 'Heal my response if needed' } ],
  model: 'openai/gpt-4o-mini',
  plugins: [ { id: 'response-healing' } ],
  temperature: 0.2,
  max_tokens: 256
)
```

Docs: https://openrouter.ai/docs/guides/features/plugins/overview